### PR TITLE
Fix query for search. Not worked in MySQL 5.5

### DIFF
--- a/home/exim4u/public_html/exim4u/adminuser.php
+++ b/home/exim4u/public_html/exim4u/adminuser.php
@@ -80,7 +80,15 @@
         $query .= " AND lower(localpart) LIKE lower(:letter)";
         $queryParams[':letter'] = $letter.'%';
         } elseif ($_POST['searchfor'] != '') {
-          $query .= ' AND ' . $dbh->quote($_POST['field']) . ' LIKE :searchfor"%';
+          $query .= ' AND ';
+          switch ($_POST['field']){
+            case "localpart":
+              $query .= 'localpart';
+              break;
+            case "realname":
+              $query .= 'realname';
+            }
+          $query .= ' LIKE :searchfor';
           $queryParams[':searchfor'] = '%'.$_POST['searchfor'].'%';
         }
         $query .= ' ORDER BY realname, localpart';


### PR DESCRIPTION
The data transferred from the form got to request. It isn't safe. But the border in quotes doesn't give the chance of MySQL to correctly recognize fields name.
